### PR TITLE
core: Use Unix epoch time for build number

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -278,11 +278,6 @@ endif
 DATE := date -d @$(BUILD_DATETIME)
 .KATI_READONLY := DATE
 
-# Everything should be using BUILD_DATETIME_FROM_FILE instead.
-# BUILD_DATETIME and DATE can be removed once BUILD_NUMBER moves
-# to soong_ui.
-$(KATI_obsolete_var BUILD_DATETIME,Use BUILD_DATETIME_FROM_FILE)
-
 HAS_BUILD_NUMBER := true
 ifndef BUILD_NUMBER
   # BUILD_NUMBER should be set to the source control value that
@@ -294,10 +289,15 @@ ifndef BUILD_NUMBER
   # If no BUILD_NUMBER is set, create a useful "I am an engineering build
   # from this date/time" value.  Make it start with a non-digit so that
   # anyone trying to parse it as an integer will probably get "0".
-  BUILD_NUMBER := eng.$(shell echo $${BUILD_USERNAME:0:6}).$(shell $(DATE) +%Y%m%d.%H%M%S)
+  BUILD_NUMBER := $(BUILD_DATETIME)
   HAS_BUILD_NUMBER := false
 endif
 .KATI_READONLY := BUILD_NUMBER HAS_BUILD_NUMBER
+
+# Everything should be using BUILD_DATETIME_FROM_FILE instead.
+# BUILD_DATETIME and DATE can be removed once BUILD_NUMBER moves
+# to soong_ui.
+$(KATI_obsolete_var BUILD_DATETIME,Use BUILD_DATETIME_FROM_FILE)
 
 ifndef PLATFORM_MIN_SUPPORTED_TARGET_SDK_VERSION
   # Used to set minimum supported target sdk version. Apps targeting sdk


### PR DESCRIPTION
Google Camera 8.2.400 crashes when attempting to take a picture with Night Sight on custom ROMs because the build number doesn't match the expected format: a signed 32-bit integer.

The parsed number is used as a gate for a burst-related change. The minimum threshold is 7168887 for RQ3A builds. The current Unix epoch time in seconds happens to be greater than this and conveys the same information as the old eng build number (except the username, which we don't want there anyway), so let's use it as the incremental build number.

NB: We change BUILD_NUMBER here instead of vendorsetup because it needs to be unique to each build, not lunch session.

Change-Id: If2b0caade2fa874719dd971a9ea7fce37f0b2af4
Signed-off-by: GhostMaster69-dev <rathore6375@gmail.com>